### PR TITLE
Fix RTC_ClearAlarm

### DIFF
--- a/Common/DemoRTCAlarm/DemoRTCAlarm/DemoRTCAlarm.ino
+++ b/Common/DemoRTCAlarm/DemoRTCAlarm/DemoRTCAlarm.ino
@@ -25,62 +25,37 @@
   (Check https://github.com/CONTROLLINO-PLC/CONTROLLINO_Library for the latest CONTROLLINO related software stuff.)
 */
 
-bool alarmActive;
-
 // The setup function runs once when you press reset (CONTROLLINO RST button) or connect power supply (USB or external 12V/24V) to the CONTROLLINO.
 void setup() {
   alarmActive = 0;
   // initialize serial communication at 9600 bits per second
   Serial.begin(9600);
-  
-  sei();
-  
   Controllino_RTC_init();
-
   Controllino_ClearAlarm();
 
   /* set time and date by separate values values to the RTC chip */
   /* Day, WeekDay, Month, Year, Hour, Minute, Second); */
-  Controllino_SetTimeDate(12,4,1,17,15,41,56); 
+  Controllino_SetTimeDate(12,4,1,17,15,41,56);
   
   /* or use another possibility and define the time and date by strings, e.g. "Nov 15 2018", "11:41:02" */
   /* following example uses predefined C macros __DATE__ and __TIME__ which represent compilation time */
   //Controllino_SetTimeDateStrings(__DATE__, __TIME__); /* set compilation time to the RTC chip */
 
   pinMode(CONTROLLINO_RTC_INTERRUPT, INPUT_PULLUP);
-
-  Controllino_SetAlarm(15,42);
+  Controllino_SetAlarm(15,55);
 }
 
 // the loop function runs over and over again forever
 void loop() {
-  int n;  
-  Serial.print("Day: ");n = Controllino_GetDay(); Serial.println(n);
-  
-  Serial.print("WeekDay: ");n = Controllino_GetWeekDay(); Serial.println(n);
-  
-  Serial.print("Month: ");n = Controllino_GetMonth(); Serial.println(n);
-
-  Serial.print("Year: ");n = Controllino_GetYear(); Serial.println(n);
-
-  Serial.print("Hour: ");n = Controllino_GetHour(); Serial.println(n);
-
-  Serial.print("Minute: "); n = Controllino_GetMinute(); Serial.println(n);
-
-  Serial.print("Second: ");n = Controllino_GetSecond(); Serial.println(n);
-
-  Serial.print("Int pin state: "); Serial.println(digitalRead(CONTROLLINO_RTC_INTERRUPT));
-
-  Serial.print("Alarm state: "); Serial.println(alarmActive);
-  
-  if (digitalRead(CONTROLLINO_RTC_INTERRUPT) = 1) {
-      Serial.println("Alarm triggered! Resetting...");
-      Controllino_ClearAlarm();
-    }
-  
-  delay(5000);        
+  Serial.print(".");
+  delay(1000);
+  if (digitalRead(CONTROLLINO_RTC_INTERRUPT) == 0) {
+    Controllino_ClearAlarm();
+    Serial.println("Alarm triggered!");
+    while(1){};
+  };
 }
 
 /* End of the example. Visit us at https://controllino.biz/ or https://github.com/CONTROLLINO-PLC/CONTROLLINO_Library or contact us at info@controllino.biz if you have any questions or troubles. */
-
 /* 2018-09-20: The sketch was successfully tested with Arduino 1.8.5, Controllino Library 3.0.2 and CONTROLLINO MINI, MAXI and MEGA. */
+/* 2023-06-06: The sketch was successfully tested with Arduino 2.1.0, Controllino Library 3.0.7 and MAXI */

--- a/Controllino.cpp
+++ b/Controllino.cpp
@@ -445,7 +445,7 @@ char Controllino_SetTimeDateStrings(const char* date, const char* time)
 }
 
 char Controllino_SetAlarm(unsigned char *aHour, unsigned char *aMinute) {
-	
+
 	unsigned char TimeDate [2]={aMinute,aHour}; //we use a zero in the middle of the array as thats how the data are stored inside the the chip
 	unsigned char i,a,b,temp;//Help variable i is used to control for cycle and a,b are used to prepare time data for the RTC chip.
 	unsigned char SPISetting; // variable to hold SPI setting
@@ -461,7 +461,7 @@ char Controllino_SetAlarm(unsigned char *aHour, unsigned char *aMinute) {
 
 		for(i = 0; i < 2;i++)
 		{
-			
+
 			if (i == 0)    //minutes
 			{
 				b = TimeDate[i]/40; //get the 40s
@@ -476,13 +476,13 @@ char Controllino_SetAlarm(unsigned char *aHour, unsigned char *aMinute) {
 				b = b+temp;
 				a = a%10; // get the rest
 			}
-			
+
 			if (i == 1)    //hours
 			{
 				b = TimeDate[i]/10; //get the 10s
 				b = b<<4;
 				a = TimeDate[i]%10; // get the rest
-				
+
 			}
 				TimeDate[i]= a + b;   
 				Controllino_SetRTCSS(HIGH);
@@ -517,7 +517,15 @@ char Controllino_ClearAlarm( void ) {
 		SPI.setDataMode(SPI_MODE0);
 		Controllino_SetRTCSS(HIGH);
 		SPI.transfer(0x11); //0x11 is address for control2 write 
-		SPI.transfer(B11110101); // clear alarms
+		SPI.transfer(B00010000); // clear alarms
+		Controllino_SetRTCSS(LOW);
+		Controllino_SetRTCSS(HIGH);
+		SPI.transfer(0x19); //0x11 is address for alarm-mins write 
+		SPI.transfer(B10000000); // clear alarms
+		Controllino_SetRTCSS(LOW);
+		Controllino_SetRTCSS(HIGH);
+		SPI.transfer(0x1A); //0x1A is address for alarm-hours write 
+		SPI.transfer(B10000000); // clear alarms
 		Controllino_SetRTCSS(LOW);
 		//Return the SPI settings to previous state
 		SPCR = SPISetting;
@@ -528,7 +536,6 @@ char Controllino_ClearAlarm( void ) {
 		return -1; //RTC chip was initialized properly, return -1
 	}
 }
-
 
 #if defined(CONTROLLINO_MAXI) || defined(CONTROLLINO_MEGA)
 


### PR DESCRIPTION
@greenveg I fixed the alarm clearing.
It detects the pin going low, clears the interrupt flags from the control2 register, and clears the values from the alarm_hours and alarm_mins registers.