### PR TITLE
Tools version updated

### DIFF
--- a/Boards/package_ControllinoHardware_index.json
+++ b/Boards/package_ControllinoHardware_index.json
@@ -224,7 +224,51 @@
               "version": "6.3.0-arduino8"
             }
           ]
-        } 
+        },
+        {
+          "name": "CONTROLLINO Boards",
+          "architecture": "avr",
+          "version": "3.1.1",
+          "category": "Contributed",
+          "url": "https://github.com/CONTROLLINO-PLC/CONTROLLINO_Library/raw/master/Boards/ControllinoHW.zip",
+          "archiveFileName": "ControllinoHW.zip",
+          "checksum": "SHA-256:3520d650305373537c295874d88805ff49230c00b8db85606ec8a63969259f31",
+          "size": "65715",
+          "help": {
+            "online": "https://www.controllino.com/tutorials/"
+          },
+          "boards": [
+            {
+              "name": "MINI"
+            },
+            {
+              "name": "MAXI"
+            },
+            {
+              "name": "MAXI Automation"
+            },
+            {
+              "name": "MEGA"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino7"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
+        }
       ],
 			"tools":[]
 		}


### PR DESCRIPTION
- Fix #60 
- Update tools to the latest version like in Arduino AVR Boards
- Adding Arduino OTA tool
- CONTROLLINO Boards version to 3.1.1